### PR TITLE
Add support for keywords hours, colnumeric, and colcasefirst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## 1.1.0 TBD
 
-- Add support for keywords `hours`, `colnumeric`, and `colcasefirst`. These
+- New #33: Add support for keywords `hours`, `colnumeric`, and `colcasefirst`. These
   keywords are part of the [ECMAScript 2022 Internationalization API Specification
   (ECMA-402 9th Edition)](https://tc39.es/ecma402/), and supporting them allows
   for better cross-communication between PHP and JavaScript layers.
@@ -11,7 +11,7 @@
     For more information see the [key/type definition for the Unicode Hour Cycle
     Identifier](https://www.unicode.org/reports/tr35/tr35-61/tr35.html#UnicodeHourCycleIdentifier).
   - `colnumeric` and `colcasefirst` are both collation settings defined as part
-    of the [Unicode Locale Data Markup Language](https://www.unicode.org/reports/tr35/tr35-61/tr35-collation.html#Collation_Settings).
+    of the [Unicode Locale Data Markup Language](https://www.unicode.org/reports/tr35/tr35-61/tr35-collation.html#Collation_Settings) (ramsey)
 
 
 ## 1.0.0 December 25, 2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,18 @@
 # Yii i18n Change Log
 
 
-## 1.0.1 under development
+## 1.1.0 TBD
 
-- no changes in this release.
+- Add support for keywords `hours`, `colnumeric`, and `colcasefirst`. These
+  keywords are part of the [ECMAScript 2022 Internationalization API Specification
+  (ECMA-402 9th Edition)](https://tc39.es/ecma402/), and supporting them allows
+  for better cross-communication between PHP and JavaScript layers.
+  - `hours` defines an hour cycle for the locale (i.e. `h11`, `h12`, `h23`, `h24`).
+    For more information see the [key/type definition for the Unicode Hour Cycle
+    Identifier](https://www.unicode.org/reports/tr35/tr35-61/tr35.html#UnicodeHourCycleIdentifier).
+  - `colnumeric` and `colcasefirst` are both collation settings defined as part
+    of the [Unicode Locale Data Markup Language](https://www.unicode.org/reports/tr35/tr35-61/tr35-collation.html#Collation_Settings).
+
 
 ## 1.0.0 December 25, 2020
 

--- a/src/Locale.php
+++ b/src/Locale.php
@@ -65,6 +65,14 @@ final class Locale
     private ?string $collation = null;
 
     /**
+     * @var string|null ICU numeric collation.
+     *
+     * @see https://unicode-org.github.io/icu/userguide/collation/customization/#numericordering
+     * @see https://www.unicode.org/reports/tr35/tr35-61/tr35-collation.html#Collation_Settings
+     */
+    private ?string $colnumeric = null;
+
+    /**
      * @var string|null ICU numbers.
      */
     private ?string $numbers = null;
@@ -143,6 +151,10 @@ final class Locale
 
                 if ($key === 'collation') {
                     $this->collation = $value;
+                }
+
+                if ($key === 'colnumeric') {
+                    $this->colnumeric = $value;
                 }
 
                 if ($key === 'currency') {
@@ -265,6 +277,32 @@ final class Locale
     {
         $new = clone $this;
         $new->collation = $collation;
+        return $new;
+    }
+
+    /**
+     * @return string|null ICU numeric collation.
+     *
+     * @see https://unicode-org.github.io/icu/userguide/collation/customization/#numericordering
+     * @see https://www.unicode.org/reports/tr35/tr35-61/tr35-collation.html#Collation_Settings
+     */
+    public function colnumeric(): ?string
+    {
+        return $this->colnumeric;
+    }
+
+    /**
+     * @param string|null $colnumeric ICU numeric collation.
+     *
+     * @see https://unicode-org.github.io/icu/userguide/collation/customization/#numericordering
+     * @see https://www.unicode.org/reports/tr35/tr35-61/tr35-collation.html#Collation_Settings
+     *
+     * @return self
+     */
+    public function withColnumeric(?string $colnumeric): self
+    {
+        $new = clone $this;
+        $new->colnumeric = $colnumeric;
         return $new;
     }
 
@@ -472,6 +510,9 @@ final class Locale
         if ($this->collation !== null) {
             $keywords[] = 'collation=' . $this->collation;
         }
+        if ($this->colnumeric !== null) {
+            $keywords[] = 'colnumeric=' . $this->colnumeric;
+        }
         if ($this->calendar !== null) {
             $keywords[] = 'calendar=' . $this->calendar;
         }
@@ -501,6 +542,7 @@ final class Locale
         $fallback = $this
             ->withCalendar(null)
             ->withCollation(null)
+            ->withColnumeric(null)
             ->withCurrency(null)
             ->withExtendedLanguage(null)
             ->withNumbers(null)

--- a/src/Locale.php
+++ b/src/Locale.php
@@ -70,6 +70,13 @@ final class Locale
     private ?string $numbers = null;
 
     /**
+     * @var string|null Unicode hour cycle identifier.
+     *
+     * @see https://www.unicode.org/reports/tr35/#UnicodeHourCycleIdentifier
+     */
+    private ?string $hours = null;
+
+    /**
      * @var string|null
      */
     private ?string $grandfathered = null;
@@ -144,6 +151,10 @@ final class Locale
 
                 if ($key === 'numbers') {
                     $this->numbers = $value;
+                }
+
+                if ($key === 'hours') {
+                    $this->hours = $value;
                 }
             }
         }
@@ -274,6 +285,30 @@ final class Locale
     {
         $new = clone $this;
         $new->numbers = $numbers;
+        return $new;
+    }
+
+    /**
+     * @return string|null Unicode hour cycle identifier.
+     *
+     * @see https://www.unicode.org/reports/tr35/#UnicodeHourCycleIdentifier
+     */
+    public function hours(): ?string
+    {
+        return $this->hours;
+    }
+
+    /**
+     * @param string|null $hours Unicode hour cycle identifier.
+     *
+     * @see https://www.unicode.org/reports/tr35/#UnicodeHourCycleIdentifier
+     *
+     * @return self
+     */
+    public function withHours(?string $hours): self
+    {
+        $new = clone $this;
+        $new->hours = $hours;
         return $new;
     }
 
@@ -443,6 +478,9 @@ final class Locale
         if ($this->numbers !== null) {
             $keywords[] = 'numbers=' . $this->numbers;
         }
+        if ($this->hours !== null) {
+            $keywords[] = 'hours=' . $this->hours;
+        }
 
         $string = implode('-', $result);
 
@@ -466,6 +504,7 @@ final class Locale
             ->withCurrency(null)
             ->withExtendedLanguage(null)
             ->withNumbers(null)
+            ->withHours(null)
             ->withPrivate(null);
 
         if ($fallback->variant() !== null) {

--- a/src/Locale.php
+++ b/src/Locale.php
@@ -60,6 +60,14 @@ final class Locale
     private ?string $calendar = null;
 
     /**
+     * @var string|null ICU case-first collation.
+     *
+     * @see https://unicode-org.github.io/icu/userguide/collation/customization/#casefirst
+     * @see https://www.unicode.org/reports/tr35/tr35-61/tr35-collation.html#Collation_Settings
+     */
+    private ?string $colcasefirst = null;
+
+    /**
      * @var string|null ICU collation.
      */
     private ?string $collation = null;
@@ -147,6 +155,10 @@ final class Locale
 
                 if ($key === 'calendar') {
                     $this->calendar = $value;
+                }
+
+                if ($key === 'colcasefirst') {
+                    $this->colcasefirst = $value;
                 }
 
                 if ($key === 'collation') {
@@ -257,6 +269,32 @@ final class Locale
     {
         $new = clone $this;
         $new->calendar = $calendar;
+        return $new;
+    }
+
+    /**
+     * @return string|null ICU case-first collation.
+     *
+     * @see https://unicode-org.github.io/icu/userguide/collation/customization/#casefirst
+     * @see https://www.unicode.org/reports/tr35/tr35-61/tr35-collation.html#Collation_Settings
+     */
+    public function colcasefirst(): ?string
+    {
+        return $this->colcasefirst;
+    }
+
+    /**
+     * @param string|null $colcasefirst ICU case-first collation.
+     *
+     * @see https://unicode-org.github.io/icu/userguide/collation/customization/#casefirst
+     * @see https://www.unicode.org/reports/tr35/tr35-61/tr35-collation.html#Collation_Settings
+     *
+     * @return self
+     */
+    public function withColcasefirst(?string $colcasefirst): self
+    {
+        $new = clone $this;
+        $new->colcasefirst = $colcasefirst;
         return $new;
     }
 
@@ -507,6 +545,9 @@ final class Locale
         if ($this->currency !== null) {
             $keywords[] = 'currency=' . $this->currency;
         }
+        if ($this->colcasefirst !== null) {
+            $keywords[] = 'colcasefirst=' . $this->colcasefirst;
+        }
         if ($this->collation !== null) {
             $keywords[] = 'collation=' . $this->collation;
         }
@@ -541,6 +582,7 @@ final class Locale
     {
         $fallback = $this
             ->withCalendar(null)
+            ->withColcasefirst(null)
             ->withCollation(null)
             ->withColnumeric(null)
             ->withCurrency(null)

--- a/tests/LocaleTest.php
+++ b/tests/LocaleTest.php
@@ -84,6 +84,12 @@ final class LocaleTest extends Testcase
         $this->assertSame('latn', $locale->numbers());
     }
 
+    public function testHoursParsedCorrectly(): void
+    {
+        $locale = new Locale('fr-FR@hours=h23');
+        $this->assertSame('h23', $locale->hours());
+    }
+
     public function testCurrencyParsedCorrectly(): void
     {
         $locale = new Locale('ru-RU@currency=USD');
@@ -104,7 +110,7 @@ final class LocaleTest extends Testcase
 
     public function testAsString(): void
     {
-        $localeString = 'zh-cmn-Hans-CN-boont-r-extended-sequence-x-private@currency=USD;collation=traditional;calendar=buddhist;numbers=latn';
+        $localeString = 'zh-cmn-Hans-CN-boont-r-extended-sequence-x-private@currency=USD;collation=traditional;calendar=buddhist;numbers=latn;hours=h24';
         $localeStringGrandFathered = 'zh-xiang';
         $locale = new Locale($localeString);
         $localeGrandFathered = new Locale($localeStringGrandFathered);
@@ -183,6 +189,16 @@ final class LocaleTest extends Testcase
 
         $this->assertNull($locale->numbers());
         $this->assertSame('latn', $newLocale->numbers());
+        $this->assertNotSame($locale, $newLocale);
+    }
+
+    public function testWithHours(): void
+    {
+        $locale = new Locale('fr');
+        $newLocale = $locale->withHours('h12');
+
+        $this->assertNull($locale->hours());
+        $this->assertSame('h12', $newLocale->hours());
         $this->assertNotSame($locale, $newLocale);
     }
 

--- a/tests/LocaleTest.php
+++ b/tests/LocaleTest.php
@@ -78,6 +78,12 @@ final class LocaleTest extends Testcase
         $this->assertSame('traditional', $locale->collation());
     }
 
+    public function testColnumericParsedCorrectly(): void
+    {
+        $locale = new Locale('fr-Latn-FR@colnumeric=yes');
+        $this->assertSame('yes', $locale->colnumeric());
+    }
+
     public function testNumbersParsedCorrectly(): void
     {
         $locale = new Locale('ru-RU@numbers=latn');
@@ -110,7 +116,7 @@ final class LocaleTest extends Testcase
 
     public function testAsString(): void
     {
-        $localeString = 'zh-cmn-Hans-CN-boont-r-extended-sequence-x-private@currency=USD;collation=traditional;calendar=buddhist;numbers=latn;hours=h24';
+        $localeString = 'zh-cmn-Hans-CN-boont-r-extended-sequence-x-private@currency=USD;collation=traditional;colnumeric=no;calendar=buddhist;numbers=latn;hours=h24';
         $localeStringGrandFathered = 'zh-xiang';
         $locale = new Locale($localeString);
         $localeGrandFathered = new Locale($localeStringGrandFathered);
@@ -209,6 +215,16 @@ final class LocaleTest extends Testcase
 
         $this->assertNull($locale->collation());
         $this->assertSame('traditional', $newLocale->collation());
+        $this->assertNotSame($locale, $newLocale);
+    }
+
+    public function testWithColnumeric(): void
+    {
+        $locale = new Locale('fr');
+        $newLocale = $locale->withColnumeric('no');
+
+        $this->assertNull($locale->colnumeric());
+        $this->assertSame('no', $newLocale->colnumeric());
         $this->assertNotSame($locale, $newLocale);
     }
 

--- a/tests/LocaleTest.php
+++ b/tests/LocaleTest.php
@@ -72,6 +72,12 @@ final class LocaleTest extends Testcase
         $this->assertSame('buddhist', $locale->calendar());
     }
 
+    public function testColcasefirstParsedCorrectly(): void
+    {
+        $locale = new Locale('fr-Latn-FR@colcasefirst=upper');
+        $this->assertSame('upper', $locale->colcasefirst());
+    }
+
     public function testCollationParsedCorrectly(): void
     {
         $locale = new Locale('es@collation=traditional');
@@ -116,7 +122,9 @@ final class LocaleTest extends Testcase
 
     public function testAsString(): void
     {
-        $localeString = 'zh-cmn-Hans-CN-boont-r-extended-sequence-x-private@currency=USD;collation=traditional;colnumeric=no;calendar=buddhist;numbers=latn;hours=h24';
+        $localeString = 'zh-cmn-Hans-CN-boont-r-extended-sequence-x-private@'
+            . 'currency=USD;colcasefirst=lower;collation=traditional;colnumeric=no;'
+            . 'calendar=buddhist;numbers=latn;hours=h24';
         $localeStringGrandFathered = 'zh-xiang';
         $locale = new Locale($localeString);
         $localeGrandFathered = new Locale($localeStringGrandFathered);
@@ -205,6 +213,16 @@ final class LocaleTest extends Testcase
 
         $this->assertNull($locale->hours());
         $this->assertSame('h12', $newLocale->hours());
+        $this->assertNotSame($locale, $newLocale);
+    }
+
+    public function testWithColcasefirst(): void
+    {
+        $locale = new Locale('fr');
+        $newLocale = $locale->withColcasefirst('false');
+
+        $this->assertNull($locale->colcasefirst());
+        $this->assertSame('false', $newLocale->colcasefirst());
         $this->assertNotSame($locale, $newLocale);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | n/a


This PR provides support for the "hours," "colnumeric," and "colcasefirst" keywords.

For example, if we use PHP's ext-intl to canonicalize the following:

```php
>>> Locale::canonicalize('fr-Latn-FR-u-kn-true-kf-upper-hc-h23')
=> "fr_Latn_FR@colcasefirst=upper;colnumeric=yes;hours=h23"
```

I'm adding them to yiisoft/i18n because these values are defined as part of [ECMAScript 2022 Internationalization API Specification (ECMA-402 9th Edition)](https://tc39.es/ecma402/), and it would be nice to parse them in PHP in a similar way.

These extensions/keywords are defined as part of the Unicode CLDR here:

* https://www.unicode.org/reports/tr35/tr35-61/tr35-collation.html#Collation_Settings
* https://www.unicode.org/reports/tr35/tr35-61/tr35.html#UnicodeHourCycleIdentifier

And as part of ICU here:

* https://unicode-org.github.io/icu/userguide/collation/customization/#casefirst
* https://unicode-org.github.io/icu/userguide/collation/customization/#numericordering
* https://github.com/unicode-org/icu/blob/1986dcd0d8c6418a266548b4decd0783914fadf8/icu4c/source/i18n/coll.cpp#L270
* https://github.com/unicode-org/icu/blob/1986dcd0d8c6418a266548b4decd0783914fadf8/icu4c/source/i18n/coll.cpp#L273
* https://github.com/unicode-org/icu/blob/e69f337f3cf3cfa8504513cdfdd72dd67e071a0e/icu4c/source/i18n/dtptngen.cpp#L672-L687