### PR TITLE
Fix #56: Fix `LocaleProvider::isDefaultLocale()` giving a wrong result if locale is set explicitly to the one matching default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.2.1 under development
 
-- no changes in this release.
+- Bug #56: Fix `LocaleProvider::isDefaultLocale()` giving a wrong result if locale is set explicitly to the one matching default (samdark)
 
 ## 1.2.0 June 04, 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.2.1 under development
 
-- Bug #56: Fix `LocaleProvider::isDefaultLocale()` giving a wrong result if locale is set explicitly to the one matching default (samdark)
+- Bug #56: Fix `LocaleProvider::isDefaultLocale()` giving a wrong result if locale is set explicitly to the one matching default (@samdark)
 
 ## 1.2.0 June 04, 2023
 

--- a/src/LocaleProvider.php
+++ b/src/LocaleProvider.php
@@ -29,6 +29,6 @@ final class LocaleProvider
 
     public function isDefaultLocale(): bool
     {
-        return $this->locale === null;
+        return $this->locale === null || $this->locale->asString() === $this->defaultLocale->asString();
     }
 }

--- a/tests/LocaleProviderTest.php
+++ b/tests/LocaleProviderTest.php
@@ -19,6 +19,18 @@ final class LocaleProviderTest extends TestCase
         $this->assertTrue($localeProvider->isDefaultLocale());
     }
 
+    public function testDefaultLocaleWhenSetExplicitly(): void
+    {
+        $defaultLocale = new Locale('en');
+        $locale = new Locale('en');
+
+        $localeProvider = new LocaleProvider($defaultLocale);
+        $localeProvider->set($locale);
+
+        $this->assertSame($locale, $localeProvider->get());
+        $this->assertTrue($localeProvider->isDefaultLocale());
+    }
+
     public function testSetLocale(): void
     {
         $defaultLocale = new Locale('en');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #56
